### PR TITLE
Feat: 커스텀 탭 바 숨김 처리, 온보딩 화면 수정

### DIFF
--- a/me-time.xcodeproj/project.pbxproj
+++ b/me-time.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		C4BFC3662CAA8FB8008AFEF7 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BFC3652CAA8FB8008AFEF7 /* API.swift */; };
 		C4BFC3682CAA95BD008AFEF7 /* YouTubeSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BFC3672CAA95BD008AFEF7 /* YouTubeSearch.swift */; };
 		C4BFC36A2CAAC918008AFEF7 /* MusicDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BFC3692CAAC918008AFEF7 /* MusicDetailView.swift */; };
+		C4DD23C32CAD654900CDED7F /* EnvironmentValues+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DD23C22CAD654900CDED7F /* EnvironmentValues+.swift */; };
 		C4E2F2EF2CA14C8D00E97157 /* CommentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E2F2EE2CA14C8D00E97157 /* CommentView.swift */; };
 		C4E2F2F32CA30CBA00E97157 /* ChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E2F2F22CA30CBA00E97157 /* ChartView.swift */; };
 		C4E2F2F62CA4417000E97157 /* CustomCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E2F2F52CA4417000E97157 /* CustomCalendarView.swift */; };
@@ -120,6 +121,7 @@
 		C4BFC3652CAA8FB8008AFEF7 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
 		C4BFC3672CAA95BD008AFEF7 /* YouTubeSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeSearch.swift; sourceTree = "<group>"; };
 		C4BFC3692CAAC918008AFEF7 /* MusicDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicDetailView.swift; sourceTree = "<group>"; };
+		C4DD23C22CAD654900CDED7F /* EnvironmentValues+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+.swift"; sourceTree = "<group>"; };
 		C4E2F2EE2CA14C8D00E97157 /* CommentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentView.swift; sourceTree = "<group>"; };
 		C4E2F2F22CA30CBA00E97157 /* ChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartView.swift; sourceTree = "<group>"; };
 		C4E2F2F52CA4417000E97157 /* CustomCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCalendarView.swift; sourceTree = "<group>"; };
@@ -263,6 +265,7 @@
 			children = (
 				C46D06B22C96BAF8001EF943 /* Font+.swift */,
 				C47A64302C9B0621003E8949 /* Color+.swift */,
+				C4DD23C22CAD654900CDED7F /* EnvironmentValues+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -472,6 +475,7 @@
 				C47A64062C9717E3003E8949 /* MusicView.swift in Sources */,
 				C46D069C2C96B6D5001EF943 /* CommonButton.swift in Sources */,
 				C47A63FD2C97177F003E8949 /* CustomTabView.swift in Sources */,
+				C4DD23C32CAD654900CDED7F /* EnvironmentValues+.swift in Sources */,
 				C4BFC3602CAA8EDF008AFEF7 /* YoutubeAPIManager.swift in Sources */,
 				C47A641E2C995FC8003E8949 /* WritingView.swift in Sources */,
 				C4E2F2F62CA4417000E97157 /* CustomCalendarView.swift in Sources */,

--- a/me-time/CustomView/CommonButton.swift
+++ b/me-time/CustomView/CommonButton.swift
@@ -23,7 +23,6 @@ struct CommonButton: View {
                 .foregroundStyle(Color("primaryWhite"))
                 .font(.morenaBold20)
         }
-        // .padding(.horizontal, 10)
     }
 }
 

--- a/me-time/Extension/EnvironmentValues+.swift
+++ b/me-time/Extension/EnvironmentValues+.swift
@@ -1,0 +1,24 @@
+//
+//  EnvironmentValues+.swift
+//  me-time
+//
+//  Created by junehee on 10/2/24.
+//
+
+import SwiftUI
+
+private struct TabBarHiddenKey: EnvironmentKey {
+    // static let defaultValue: Bool = false
+    static let defaultValue: Binding<Bool> = .constant(false)
+}
+
+extension EnvironmentValues {
+    // var isTabBarHidden: Bool {
+    //     get { self[TabBarVisibilityKey.self] }
+    //     set { self[TabBarVisibilityKey.self] = newValue }
+    // }
+    var isTabBarHidden: Binding<Bool> {
+        get { self[TabBarHiddenKey.self] }
+        set { self[TabBarHiddenKey.self] = newValue }
+    }
+}

--- a/me-time/Presentation/LaunchScreen/LaunchScreenView.swift
+++ b/me-time/Presentation/LaunchScreen/LaunchScreenView.swift
@@ -11,18 +11,24 @@ struct LaunchScreenView: View {
     var body: some View {
         ZStack(alignment: .center) {
             Image("gradientBackground")
+                .resizable()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .ignoresSafeArea()
+            
             // LinearGradient(
             //     gradient: Gradient(stops: [
-            //         .init(color: Color("primarySand").opacity(0), location: 0.0),
+            //         .init(color: Color("primarySand").opacity(1), location: 0.0),
             //         .init(color: Color("primaryGreen"), location: 0.7)
             //     ]),
             //     startPoint: .top,
             //     endPoint: .bottom
             // )
             // .ignoresSafeArea()
+            
             Image("launchScreen")
+                .aspectRatio(contentMode: .fit)
         }
+        // .aspectRatio(.infinity, contentMode: .fill)
     }
 }
 

--- a/me-time/Presentation/MorningPaper/DetailView.swift
+++ b/me-time/Presentation/MorningPaper/DetailView.swift
@@ -12,6 +12,8 @@ struct DetailView: View {
     
     @ObservedRealmObject var detailData: MorningPaper
     
+    @Environment(\.isTabBarHidden) private var isTabBarHidden: Binding<Bool>
+    
     @State private var showComment = false
     
     var body: some View {
@@ -38,6 +40,12 @@ struct DetailView: View {
         .sheet(isPresented: $showComment) {
             CommentView(detailData: detailData, showComment: $showComment)
                 .presentationDetents([.medium, .large])
+        }
+        .onAppear {
+            isTabBarHidden.wrappedValue = true
+        }
+        .onDisappear {
+            isTabBarHidden.wrappedValue = false
         }
     }
     

--- a/me-time/Presentation/MorningPaper/MorningPaperView.swift
+++ b/me-time/Presentation/MorningPaper/MorningPaperView.swift
@@ -10,6 +10,8 @@ import RealmSwift
 
 struct MorningPaperView: View {
     
+    @Environment(\.isTabBarHidden) private var isTabBarHidden: Binding<Bool>
+    
     private let repository = MorningPaperTableRepository()
     
     private enum MorningPaperFilterType: String, CaseIterable {
@@ -119,6 +121,7 @@ struct MorningPaperView: View {
         
         return NavigationLink {
             DetailView(detailData: item)
+                .environment(\.isTabBarHidden, isTabBarHidden)
         } label: {
             HStack {
                 ZStack {

--- a/me-time/Presentation/Music/MusicDetailView.swift
+++ b/me-time/Presentation/Music/MusicDetailView.swift
@@ -9,12 +9,21 @@ import SwiftUI
 import WebKit
 
 struct MusicDetailView: View {
+    
+    @Environment(\.isTabBarHidden) private var isTabBarHidden: Binding<Bool>
+    
     var url: String
     
     var body: some View {
         YouTubeWebView(url: url)
             .asCustomBackButton()
             .padding(.top, 10)
+            .onAppear {
+                isTabBarHidden.wrappedValue = true
+            }
+            .onDisappear {
+                isTabBarHidden.wrappedValue = false
+            }
     }
 }
 
@@ -36,8 +45,4 @@ struct YouTubeWebView: UIViewRepresentable {
         guard let url = URL(string: url) else { return }
         webView.load(URLRequest(url: url))
     }
-}
-
-#Preview {
-    MusicDetailView(url: "https://www.youtube.com/")
 }

--- a/me-time/Presentation/Music/MusicView.swift
+++ b/me-time/Presentation/Music/MusicView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct MusicView: View {
+
+    @Environment(\.isTabBarHidden) private var isTabBarHidden: Binding<Bool>
     
     @State private var isLoading = true
     @State private var isFirstLoading = true
@@ -78,6 +80,7 @@ struct MusicView: View {
     private func playListCell(_ item: YouTubeSearchItems) -> some View {
         NavigationLink {
             MusicDetailView(url: "https://www.youtube.com/watch?v=\(item.id.videoId)")
+                .environment(\.isTabBarHidden, isTabBarHidden)
         } label: {
             VStack {
                 AsyncImage(url: URL(string: item.snippet.thumbnails.medium.url)) { image in

--- a/me-time/Presentation/Onboarding/OnboardingView.swift
+++ b/me-time/Presentation/Onboarding/OnboardingView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct OnboardingView: View {
     
+    // @Environment(\.safeAreaInsets) private var safeAreaInsets
     @Binding var isUser: Bool
     
     var body: some View {
@@ -28,13 +29,13 @@ struct OnboardingView: View {
                         
                         isUser = true
                     }
-                    .padding(.bottom, 60)
+                    .padding(.bottom, 10)
             }
         }
     }
     
 }
 
-// #Preview {
-//     OnboardingView(isUser: $isUser)
-// }
+#Preview {
+    OnboardingView(isUser: .constant(false))
+}

--- a/me-time/Presentation/Setting/ChangeNicknameView.swift
+++ b/me-time/Presentation/Setting/ChangeNicknameView.swift
@@ -48,7 +48,7 @@ struct ChangeNicknameView: View {
             .font(.caption)
             .foregroundStyle(.primaryBlack.opacity(0.5))
             
-            CommonButton(title: "변경하기")
+            CommonButton(title: "Change`")
                 .wrapToButton {
                     print("닉네임 변경 >>>", nickname)
                     changeNickname()
@@ -101,9 +101,6 @@ struct ChangeNicknameView: View {
             alertTitle = .notOnlyEnglish
             showAlert.toggle()
         }
-        
-        
-        
     }
     
     func isEnglishOnly(_ text: String) -> Bool {
@@ -111,8 +108,4 @@ struct ChangeNicknameView: View {
         let predicate = NSPredicate(format:"SELF MATCHES %@", regex)
         return predicate.evaluate(with: text)
     }
-}
-
-#Preview {
-    ChangeNicknameView()
 }

--- a/me-time/Presentation/Setting/ChangeNicknameView.swift
+++ b/me-time/Presentation/Setting/ChangeNicknameView.swift
@@ -15,6 +15,7 @@ struct ChangeNicknameView: View {
     @State private var alertTitle: NicknameAlertCase = .empty
     
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.isTabBarHidden) private var isTabBarHidden: Binding<Bool>
     
     private enum NicknameAlertCase: String {
         case empty = "닉네임을 입력해 주세요."
@@ -66,6 +67,12 @@ struct ChangeNicknameView: View {
             Spacer()
         }
         .asCustomBackButton()
+        .onAppear {
+            isTabBarHidden.wrappedValue = true
+        }
+        .onDisappear {
+            isTabBarHidden.wrappedValue = false
+        }
     }
     
     private func changeNickname() {

--- a/me-time/Presentation/Setting/SettingView.swift
+++ b/me-time/Presentation/Setting/SettingView.swift
@@ -10,6 +10,7 @@ import RealmSwift
 
 struct SettingView: View {
     
+    @Environment(\.isTabBarHidden) private var isTabBarHidden: Binding<Bool>
     @Environment(\.openURL) var openURL
     
     /// 닉네임
@@ -80,6 +81,7 @@ struct SettingView: View {
                 case .changeNickname:
                     NavigationLink {
                         ChangeNicknameView()
+                            .environment(\.isTabBarHidden, isTabBarHidden)
                     } label: {
                         Text(menu.rawValue)
                     }

--- a/me-time/Presentation/Tab/CustomTabView.swift
+++ b/me-time/Presentation/Tab/CustomTabView.swift
@@ -24,6 +24,7 @@ struct TabButtonStyle: ButtonStyle {
 
 struct ContentView: View {
     
+    @State private var isTabBarHidden: Bool = false
     @State private var selectedTab: TabType = .main
     
     var body: some View {
@@ -32,6 +33,7 @@ struct ContentView: View {
             case .main:
                 NavigationView {
                     MorningPaperView()
+                        .environment(\.isTabBarHidden, $isTabBarHidden)
                 }
             case .data:
                 NavigationView {
@@ -40,16 +42,22 @@ struct ContentView: View {
             case .music:
                 NavigationView {
                     MusicView()
+                        .environment(\.isTabBarHidden, $isTabBarHidden)
                 }
             case .setting:
                 NavigationView {
                     SettingView()
+                        .environment(\.isTabBarHidden, $isTabBarHidden)
                 }
             }
             VStack {
-                Spacer()
-                CustomTabView(selectedTab: $selectedTab)
-                    .frame(height: 50)
+                if !isTabBarHidden {
+                    Spacer()
+                    CustomTabView(selectedTab: $selectedTab)
+                        .frame(height: 50)
+                        .padding(.bottom, 1)
+                        .opacity(isTabBarHidden ? 0 : 1)
+                }
             }
             
         }

--- a/me-time/Presentation/Tab/CustomTabView.swift
+++ b/me-time/Presentation/Tab/CustomTabView.swift
@@ -59,7 +59,7 @@ struct ContentView: View {
                         .opacity(isTabBarHidden ? 0 : 1)
                 }
             }
-            
+            .padding(.bottom, 10)
         }
     }
     

--- a/me-time/me_timeApp.swift
+++ b/me-time/me_timeApp.swift
@@ -16,8 +16,6 @@ import SwiftUI
 struct me_timeApp: App {
     
     @State var isLaunching = true
-    @State var isTodayEmotion = false
-    
     @State var isUser = UserDefaultsManager.isUser
     
     var body: some Scene {


### PR DESCRIPTION
## ✨ PR 타입
- [x] 기능 작업
- [x] 디자인 작업
- [ ] 버그 수정
- [ ] 사소한 수정
- [ ] 리팩토링
- [ ] ETC.

<br />

## 🚀 작업 내용
- @ Environment를 통해 커스텀 탭 바를 사용하지 않는 화면에서 탭 바 숨김 처리
  - 모닝페이퍼 상세 화면
  - 플레이리스트 상세 화면
  - 닉네임 변경 화면
- 온보딩 화면 버튼 레이아웃 수정
- 커스텀 탭바 하단 패딩 수정

<br />

## 📱 스크린샷

| 모닝페이퍼 상세 화면 | 플레이리스트 웹뷰 | 닉네임 수정 화면 |
|:------------------:|:---------------:|:---------------:|
| <img width="350" src="https://github.com/user-attachments/assets/91f7c76e-ef06-434c-888f-9da06ac66a6e" /> | <img width="350" src="https://github.com/user-attachments/assets/21fca121-0800-46c0-850e-8e1a6d47a5eb" /> | <img width="350" src="https://github.com/user-attachments/assets/e80920ba-1874-406f-8c5d-e3225256d30a" /> |
| ![](https://github.com/user-attachments/assets/db0a77c5-324e-4b94-a329-8ce32baf9ae9) |  ![](https://github.com/user-attachments/assets/b54a8517-c23c-4efa-aca1-7399b69146bc) | ![](https://github.com/user-attachments/assets/ae11e836-1c2e-4ba2-82f7-03d04091dd30) |

<br /><br />

## ⛓️ 관련 issue
closed #17 